### PR TITLE
Fix for validation on socket OR ipv4

### DIFF
--- a/src/Shpasser/GaeSupportL5/Setup/SetupCommand.php
+++ b/src/Shpasser/GaeSupportL5/Setup/SetupCommand.php
@@ -39,7 +39,7 @@ class SetupCommand extends Command {
         $dbHost   = $this->option('db-host');
         $dbName   = $this->option('db-name');
 
-        if ( ! is_null($dbName) && (is_null($dbSocket) || is_null($dbHost)))
+        if ( ! is_null($dbName) && (is_null($dbSocket) && is_null($dbHost)))
         {
             $this->error("Option '--db-name' requires at least one of: '--db-socket' OR '--db-host' to be defined.");
             return;


### PR DESCRIPTION
Your current logic only passes if you provide both `--db-socket` AND `--db-host`, not just one or the other as the check is intended for.