### PR TITLE
Laravel5.4 - Using the singleton method instead the Removed share method

### DIFF
--- a/src/Shpasser/GaeSupportL5/GaeSupportServiceProvider.php
+++ b/src/Shpasser/GaeSupportL5/GaeSupportServiceProvider.php
@@ -36,7 +36,7 @@ class GaeSupportServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['gae.setup'] = $this->app->share(function ($app) {
+        $this->app->singleton('gae.setup', function ($app) {
             return new SetupCommand;
         });
 


### PR DESCRIPTION
The `share()` method has been removed from this commit.

[Removing some old methods such as share() in favor of the more common and documented singleton().](https://github.com/laravel/framework/commit/1a1969b6e6f793c3b2a479362641487ee9cbf736)

So we should begin using the singleton method instead.
thanks!